### PR TITLE
Optional finalizers

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -7,3 +7,5 @@ pipelineConfig:
       value: "false"
     - name: UPDATE_OWASP_DB
       value: "false"
+    - name: ENTANDO_DOCKER_IMAGE_INFO_CONFIGMAP
+      value: "entando-docker-image-info-v6.1"

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
         <entando.k8s.custom.model.version>6.1.3</entando.k8s.custom.model.version>
+        <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
+        <postDeploymentTestGroups>none</postDeploymentTestGroups>
     </properties>
     <issueManagement>
         <system>Github</system>

--- a/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
+++ b/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
@@ -164,7 +164,7 @@ public abstract class AbstractDbAwareController<T extends EntandoBaseCustomResou
         }
     }
 
-    private boolean shouldAddFinalizer() {
+    protected boolean shouldAddFinalizer() {
         return EntandoOperatorConfigBase.lookupProperty(EntandoOperatorConfigProperty.ENTANDO_REGISTER_FINALIZER).orElse("true").equalsIgnoreCase("true");
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
+++ b/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
@@ -165,7 +165,8 @@ public abstract class AbstractDbAwareController<T extends EntandoBaseCustomResou
     }
 
     protected boolean shouldAddFinalizer() {
-        return EntandoOperatorConfigBase.lookupProperty(EntandoOperatorConfigProperty.ENTANDO_REGISTER_FINALIZER).orElse("true").equalsIgnoreCase("true");
+        return EntandoOperatorConfigBase.lookupProperty(EntandoOperatorConfigProperty.ENTANDO_REGISTER_FINALIZER).orElse("true")
+                .equalsIgnoreCase("true");
     }
 
     protected void cleanBeforeDeletion(T newResource) {

--- a/src/main/java/org/entando/kubernetes/controller/EntandoOperatorConfigProperty.java
+++ b/src/main/java/org/entando/kubernetes/controller/EntandoOperatorConfigProperty.java
@@ -53,6 +53,7 @@ public enum EntandoOperatorConfigProperty {
     /*
     Misc config
      */
+    ENTANDO_REGISTER_FINALIZER("entando.register.finalizer"),
     ENTANDO_DEFAULT_ROUTING_SUFFIX("entando.default.routing.suffix"),
     ENTANDO_POD_COMPLETION_TIMEOUT_SECONDS("entando.pod.completion.timeout.seconds"),
     ENTANDO_POD_READINESS_TIMEOUT_SECONDS("entando.pod.readiness.timeout.seconds"),

--- a/src/main/java/org/entando/kubernetes/controller/common/ControllerExecutor.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/ControllerExecutor.java
@@ -137,9 +137,9 @@ public class ControllerExecutor {
 
     private List<EnvVar> buildEnvVars(Action action, EntandoCustomResource resource) {
         ArrayList<EnvVar> result = new ArrayList<>();
-        result.add(new EnvVar("ENTANDO_RESOURCE_ACTION", action.name(), null));
-        result.add(new EnvVar("ENTANDO_RESOURCE_NAMESPACE", resource.getMetadata().getNamespace(), null));
-        result.add(new EnvVar("ENTANDO_RESOURCE_NAME", resource.getMetadata().getName(), null));
+        result.add(new EnvVar(KubeUtils.ENTANDO_RESOURCE_ACTION, action.name(), null));
+        result.add(new EnvVar(KubeUtils.ENTANDO_RESOURCE_NAMESPACE, resource.getMetadata().getNamespace(), null));
+        result.add(new EnvVar(KubeUtils.ENTANDO_RESOURCE_NAME, resource.getMetadata().getName(), null));
         result.addAll(Stream.of(EntandoOperatorConfigProperty.values())
                 .filter(prop -> EntandoOperatorConfigBase.lookupProperty(prop).isPresent())
                 .map(prop -> new EnvVar(prop.name(), EntandoOperatorConfigBase.lookupProperty(prop).get(), null))

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/MinimalKeycloakContainer.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/MinimalKeycloakContainer.java
@@ -19,7 +19,7 @@ package org.entando.kubernetes.controller.common.examples;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import java.util.List;
 import java.util.Optional;
-import org.entando.kubernetes.controller.integrationtest.KeycloakClientIT;
+import org.entando.kubernetes.controller.integrationtest.KeycloakClientTest;
 import org.entando.kubernetes.controller.spi.IngressingContainer;
 
 public class MinimalKeycloakContainer implements IngressingContainer {
@@ -56,7 +56,7 @@ public class MinimalKeycloakContainer implements IngressingContainer {
     public void addEnvironmentVariables(List<EnvVar> vars) {
         vars.add(new EnvVar("DB_VENDOR", "h2", null));
         vars.add(new EnvVar("KEYCLOAK_USER", "test-admin", null));
-        vars.add(new EnvVar("KEYCLOAK_PASSWORD", KeycloakClientIT.KCP, null));
+        vars.add(new EnvVar("KEYCLOAK_PASSWORD", KeycloakClientTest.KCP, null));
     }
 
     @Override

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ContainerUsingExternalDatabaseMockClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ContainerUsingExternalDatabaseMockClientTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.mockito.Mockito;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class ContainerUsingExternalDatabaseMockClientTest extends ContainerUsingExternalDatabaseTestBase {
 
     private SimpleK8SClientDouble simpleK8SClientDouble = new SimpleK8SClientDouble();

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ControllerExecutorMockClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ControllerExecutorMockClientTest.java
@@ -21,7 +21,7 @@ import org.entando.kubernetes.controller.k8sclient.SimpleK8SClient;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class ControllerExecutorMockClientTest extends ControllerExecutorTestBase {
 
     SimpleK8SClientDouble simpleK8SClientDouble = new SimpleK8SClientDouble();

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ControllerExecutorMockServerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ControllerExecutorMockServerTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 @EnableRuleMigrationSupport
 public class ControllerExecutorMockServerTest extends ControllerExecutorTestBase {
 

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/DefaultClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/DefaultClientTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 @EnableRuleMigrationSupport
 public class DefaultClientTest {
 

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class ImageResolutionTest {
 
     private Map<String, String> storedProps = new ConcurrentHashMap<>();

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
@@ -36,16 +36,11 @@ import org.junit.jupiter.api.Test;
 @Tags({@Tag("in-process"), @Tag("pre-deployment")})
 public class ImageResolutionTest {
 
-    private Map<String, String> storedProps = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<Object, Object> storedProps = new ConcurrentHashMap<>();
 
     @BeforeEach
     public void backupSystemProperties() {
-        Stream.of(EntandoOperatorConfigProperty.values()).forEach(p -> {
-            if (System.getProperties().containsKey(p.getJvmSystemProperty())) {
-                storedProps.put(p.getJvmSystemProperty(), (String) System.getProperties().remove(p.getJvmSystemProperty()));
-            }
-        });
-
+        storedProps=new ConcurrentHashMap<>(System.getProperties());
     }
 
     @AfterEach

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
@@ -51,6 +51,7 @@ public class ImageResolutionTest {
     @AfterEach
     public void restoreSystemProperties() {
         System.getProperties().putAll(storedProps);
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_DOCKER_IMAGE_VERSION_OVERRIDE.getJvmSystemProperty());
     }
 
     @Test

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
-@Tags({@Tag("in-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"), @Tag("pre-deployment")})
 public class ImageResolutionTest {
 
     private Map<String, String> storedProps = new ConcurrentHashMap<>();
@@ -50,8 +50,10 @@ public class ImageResolutionTest {
 
     @AfterEach
     public void restoreSystemProperties() {
+        Stream.of(EntandoOperatorConfigProperty.values()).forEach(p -> {
+            System.getProperties().remove(p.getJvmSystemProperty());
+        });
         System.getProperties().putAll(storedProps);
-        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_DOCKER_IMAGE_VERSION_OVERRIDE.getJvmSystemProperty());
     }
 
     @Test

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/ImageResolutionTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -40,7 +39,7 @@ public class ImageResolutionTest {
 
     @BeforeEach
     public void backupSystemProperties() {
-        storedProps=new ConcurrentHashMap<>(System.getProperties());
+        storedProps = new ConcurrentHashMap<>(System.getProperties());
     }
 
     @AfterEach

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/InProcessTestUtil.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/InProcessTestUtil.java
@@ -40,7 +40,7 @@ import org.entando.kubernetes.model.plugin.EntandoPluginBuilder;
 import org.entando.kubernetes.model.plugin.PluginSecurityLevel;
 
 /**
- * Mostly a source of test fixture factories. TODO: These need to refactored to be inter-process friendly
+ * Mostly a source of test fixture factories. TODO: These need to refactored to be in-process friendly
  */
 public interface InProcessTestUtil extends VolumeMatchAssertions, K8SStatusBasedAnswers, K8SResourceArgumentMatchers,
         StandardArgumentCaptors {

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingMockClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingMockClientTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class PublicIngressingMockClientTest extends PublicIngressingTestBase {
 
     SimpleK8SClientDouble simpleK8SClientDouble = new SimpleK8SClientDouble();

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingMockServerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingMockServerTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
  * still have to set them somehow to test status updates. <br/> Future possibilities: <br/> We can perhaps implement test cases to run in
  * one of three modes: <br/> 1. Mockito mocked. <br/> 2. Mockserver. <br/> 3. Actual server.
  */
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 @EnableRuleMigrationSupport
 public class PublicIngressingMockServerTest extends PublicIngressingTestBase implements PodBehavior {
 

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/SpringBootContainerMockClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/SpringBootContainerMockClientTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.mockito.Mockito;
 
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class SpringBootContainerMockClientTest extends SpringBootContainerTestBase {
 
     private SimpleK8SClientDouble simpleK8SClientDouble = new SimpleK8SClientDouble();

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployDatabaseTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployDatabaseTest.java
@@ -65,7 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 //in execute component test
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class DeployDatabaseTest implements InProcessTestUtil, FluentTraversals {
 
     private static final String MY_KEYCLOAK_DB = MY_KEYCLOAK + "-db";

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployEntandoDbConsumerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployEntandoDbConsumerTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 //in execute component test
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class DeployEntandoDbConsumerTest implements InProcessTestUtil, FluentTraversals {
 
     @Spy

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployExampleServiceOnExternalDatabaseTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployExampleServiceOnExternalDatabaseTest.java
@@ -60,7 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 //in execute component test
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class DeployExampleServiceOnExternalDatabaseTest implements InProcessTestUtil, FluentTraversals {
 
     public static final String MY_KEYCLOAK_SERVER_DEPLOYMENT = MY_KEYCLOAK + "-server-deployment";

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployExampleServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/legacy/DeployExampleServiceTest.java
@@ -81,7 +81,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 //in execute component test
-@Tags({@Tag("inter-process"),@Tag("pre-deployment") })
+@Tags({@Tag("in-process"),@Tag("pre-deployment") })
 public class DeployExampleServiceTest implements InProcessTestUtil, FluentTraversals {
 
     private static final String MY_KEYCLOAK_ADMIN_SECRET = MY_KEYCLOAK + "-admin-secret";

--- a/src/test/java/org/entando/kubernetes/controller/integrationtest/AddExampleWithEmbeddedDatabaseTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/integrationtest/AddExampleWithEmbeddedDatabaseTest.java
@@ -60,8 +60,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 
-@Tags({@Tag("inter-process"), @Tag("pre-deployment"), @Tag("smoke-test")})
-public class AddExampleWithEmbeddedDatabaseIT implements FluentIntegrationTesting, InProcessTestUtil {
+@Tags({@Tag("inter-process"), @Tag("pre-deployment")})
+public class AddExampleWithEmbeddedDatabaseTest implements FluentIntegrationTesting, InProcessTestUtil {
 
     static final int KEYCLOAK_DB_PORT = 5432;
     private final K8SIntegrationTestHelper helper = new K8SIntegrationTestHelper();

--- a/src/test/java/org/entando/kubernetes/controller/integrationtest/KeycloakClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/integrationtest/KeycloakClientTest.java
@@ -58,8 +58,8 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-@Tags({@Tag("inter-process"), @Tag("pre-deployment"), @Tag("smoke-test")})
-public class KeycloakClientIT implements FluentIntegrationTesting {
+@Tags({@Tag("inter-process"), @Tag("pre-deployment")})
+public class KeycloakClientTest implements FluentIntegrationTesting {
 
     public static final String KCP = "7UTcVFN0HzaPQmV4bJDE";//RandomStringUtils.randomAlphanumeric(20);
 


### PR DESCRIPTION
This PR introduces the following changes:
1. The method org.entando.kubernetes.controller.AbstractDbAwareController#shouldAddFinalizer that allows a controller to decide if it supports finalizers or not
2. A default implementation of this method that looks for the environment variable ENTANDO_REGISTER_FINALIZER , with a default value of 'true'
3. Fix for a bug on the ImageResolutionTest that permanently modified system properties with resetting them
4. Inclusion of the old integration tests in the pre-deployment-verification phase