### PR TITLE
Eng 1218 configurable resource requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.entando</groupId>
-        <version>6.2.0</version>
+        <version>6.2.1</version>
         <artifactId>entando-quarkus-parent</artifactId>
         <relativePath/>
     </parent>
@@ -65,7 +65,7 @@
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
-        <entando.k8s.custom.model.version>6.2.0</entando.k8s.custom.model.version>
+        <entando.k8s.custom.model.version>6.2.1</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>none</postDeploymentTestGroups>
     </properties>

--- a/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
+++ b/src/main/java/org/entando/kubernetes/controller/AbstractDbAwareController.java
@@ -158,7 +158,7 @@ public abstract class AbstractDbAwareController<T extends EntandoBaseCustomResou
         }
     }
 
-    protected DatabaseServiceResult prepareDatabaseService(EntandoCustomResource entandoCustomResource, DbmsVendor dbmsVendor,
+    protected DatabaseServiceResult prepareDatabaseService(EntandoBaseCustomResource<?> entandoCustomResource, DbmsVendor dbmsVendor,
             String nameQualifier) {
         Optional<ExternalDatabaseDeployment> externalDatabase = k8sClient.entandoResources()
                 .findExternalDatabase(entandoCustomResource, dbmsVendor);

--- a/src/main/java/org/entando/kubernetes/controller/DeployCommand.java
+++ b/src/main/java/org/entando/kubernetes/controller/DeployCommand.java
@@ -39,6 +39,7 @@ import org.entando.kubernetes.controller.spi.ServiceBackingContainer;
 import org.entando.kubernetes.controller.spi.ServiceResult;
 import org.entando.kubernetes.model.AbstractServerStatus;
 import org.entando.kubernetes.model.DbServerStatus;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.WebServerStatus;
 
@@ -59,7 +60,7 @@ public class DeployCommand<T extends ServiceResult> {
     private final KeycloakClientCreator keycloakClientCreator;
     private final ServiceAccountCreator serviceAccountCreator;
     private final AbstractServerStatus status;
-    private final EntandoCustomResource entandoCustomResource;
+    private final EntandoBaseCustomResource<?> entandoCustomResource;
     private Pod pod;
 
     public DeployCommand(Deployable<T> deployable) {

--- a/src/main/java/org/entando/kubernetes/controller/EntandoOperatorConfigProperty.java
+++ b/src/main/java/org/entando/kubernetes/controller/EntandoOperatorConfigProperty.java
@@ -41,6 +41,7 @@ public enum EntandoOperatorConfigProperty {
     ENTANDO_NAMESPACES_TO_OBSERVE("entando.namespaces.to.observe"),
     ENTANDO_K8S_OPERATOR_SERVICEACCOUNT("entando.k8s.operator.serviceaccount"),
     ENTANDO_K8S_OPERATOR_IMPOSE_DEFAULT_LIMITS("entando.k8s.operator.impose.default.limits"),
+    ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO("entando.k8s.operator.request.to.limit.ratio"),
     ENTANDO_K8S_OPERATOR_FORCE_DB_PASSWORD_RESET("entando.k8s.operator.force.db.password.reset"),
 
     /*

--- a/src/main/java/org/entando/kubernetes/controller/SecretBasedCredentials.java
+++ b/src/main/java/org/entando/kubernetes/controller/SecretBasedCredentials.java
@@ -21,18 +21,18 @@ import static java.util.Optional.ofNullable;
 import io.fabric8.kubernetes.api.model.Secret;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Optional;
 
 public interface SecretBasedCredentials {
 
     default String decodeSecretValue(String key) {
-        String value = ofNullable(getSecret().getData()).map(stringStringMap -> stringStringMap.get(key)).orElse(null);
+        String value = ofNullable(getSecret().getData()).map(data -> data.get(key)).orElse(null);
         if (value == null) {
             //If not yet reloaded
-            return getSecret().getStringData().get(key);
+            return ofNullable(getSecret().getStringData()).map(data -> data.get(key)).orElse(null);
         } else {
             return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
         }
-
     }
 
     default String getUsername() {

--- a/src/main/java/org/entando/kubernetes/controller/common/InfrastructureConfig.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/InfrastructureConfig.java
@@ -31,10 +31,10 @@ public class InfrastructureConfig {
     }
 
     public static String decodeSecretValue(Secret secret, String key) {
-        String value = ofNullable(secret.getData()).map(stringStringMap -> stringStringMap.get(key)).orElse(null);
+        String value = ofNullable(secret.getData()).map(data -> data.get(key)).orElse(null);
         if (value == null) {
             //If not yet reloaded
-            return secret.getStringData().get(key);
+            return ofNullable(secret.getStringData()).map(data -> data.get(key)).orElse(null);
         } else {
             return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
         }
@@ -48,16 +48,8 @@ public class InfrastructureConfig {
         return decodeSecretValue(getInfrastructureSecret(), "entandoK8SServiceInternalUrl");
     }
 
-    public String getUserManagementInternalUrl() {
-        return decodeSecretValue(getInfrastructureSecret(), "userManagementInternalUrl");
-    }
-
     public String getK8SExternalServiceUrl() {
         return decodeSecretValue(getInfrastructureSecret(), "entandoK8SServiceExternalUrl");
-    }
-
-    public String getUserManagementExternalUrl() {
-        return decodeSecretValue(getInfrastructureSecret(), "userManagementExternalUrl");
     }
 
     public String getK8sServiceClientId() {

--- a/src/main/java/org/entando/kubernetes/controller/common/LimitAndRequestCalculator.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/LimitAndRequestCalculator.java
@@ -1,0 +1,64 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.common;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.ParseException;
+import org.entando.kubernetes.controller.EntandoOperatorConfig;
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+
+public class LimitAndRequestCalculator {
+
+    protected DecimalFormat format = new DecimalFormat("#.###");
+
+    protected LimitAndRequestCalculator() {
+        DecimalFormatSymbols newSymbols = new DecimalFormatSymbols();
+        newSymbols.setDecimalSeparator('.');
+        format.setDecimalFormatSymbols(newSymbols);
+    }
+
+    protected String applyRequestRatio(String memoryLimit) {
+        int i = findIndexOfUnitOfMeasurement(memoryLimit);
+        double number = this.parse(memoryLimit.substring(0, i)).doubleValue();
+        String uom = memoryLimit.substring(i);
+        return format.format(number * getRequestToLimitRatio()) + uom;
+    }
+
+    private int findIndexOfUnitOfMeasurement(String memoryLimit) {
+        int i = 0;
+        for (i = memoryLimit.length(); i > 0; i--) {
+            if (!Character.isAlphabetic(memoryLimit.charAt(i - 1))) {
+                break;
+            }
+        }
+        return i;
+    }
+
+    protected double getRequestToLimitRatio() {
+        return EntandoOperatorConfig.lookupProperty(
+                EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO).map(this::parse).orElse(0.1d).doubleValue();
+    }
+
+    private Number parse(String source) {
+        try {
+            return format.parse(source);
+        } catch (ParseException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/org/entando/kubernetes/controller/common/ParameterizedResourceCalculator.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/ParameterizedResourceCalculator.java
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.common;
+
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
+import org.entando.kubernetes.model.EntandoResourceRequirements;
+
+public class ParameterizedResourceCalculator extends ResourceCalculator {
+
+    private final EntandoResourceRequirements resourceRequirements;
+
+    public ParameterizedResourceCalculator(ParameterizableContainer container) {
+        super(container);
+        this.resourceRequirements = container.getCustomResourceSpec().getResourceRequirements().orElse(new EntandoResourceRequirements());
+    }
+
+    public String getMemoryLimit() {
+        return resourceRequirements.getMemoryLimit().orElse(super.getMemoryLimit());
+    }
+
+    public String getMemoryRequest() {
+        return this.resourceRequirements.getMemoryRequest().orElse(super.getMemoryRequest());
+    }
+
+    public String getCpuLimit() {
+        return resourceRequirements.getCpuLimit().orElse(super.getCpuLimit());
+    }
+
+    public String getCpuRequest() {
+        return this.resourceRequirements.getCpuRequest().orElse(super.getCpuRequest());
+    }
+}

--- a/src/main/java/org/entando/kubernetes/controller/common/ParameterizedStorageCalculator.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/ParameterizedStorageCalculator.java
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.common;
+
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
+import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
+import org.entando.kubernetes.model.EntandoResourceRequirements;
+
+public class ParameterizedStorageCalculator extends StorageCalculator {
+
+    private final EntandoResourceRequirements resourceRequirements;
+
+    public ParameterizedStorageCalculator(ParameterizableContainer container) {
+        super((PersistentVolumeAware) container);
+        this.resourceRequirements = container.getCustomResourceSpec().getResourceRequirements().orElse(new EntandoResourceRequirements());
+    }
+
+    public String getStorageLimit() {
+        return resourceRequirements.getStorageLimit().orElse(super.getStorageLimit());
+    }
+
+    public String getStorageRequest() {
+        return this.resourceRequirements.getStorageRequest().orElse(super.getStorageRequest());
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/controller/common/ResourceCalculator.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/ResourceCalculator.java
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.common;
+
+import org.entando.kubernetes.controller.spi.DeployableContainer;
+
+public class ResourceCalculator extends LimitAndRequestCalculator {
+
+    private final DeployableContainer container;
+
+    public ResourceCalculator(DeployableContainer container) {
+        this.container = container;
+    }
+
+    public String getMemoryLimit() {
+        return container.getMemoryLimitMebibytes() + "Mi";
+    }
+
+    public String getCpuLimit() {
+        return container.getCpuLimitMillicores() + "m";
+    }
+
+    public String getMemoryRequest() {
+        return applyRequestRatio(getMemoryLimit());
+    }
+
+    public String getCpuRequest() {
+        return applyRequestRatio(getCpuLimit());
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/controller/common/StorageCalculator.java
+++ b/src/main/java/org/entando/kubernetes/controller/common/StorageCalculator.java
@@ -14,14 +14,24 @@
  *
  */
 
-package org.entando.kubernetes.controller.spi;
+package org.entando.kubernetes.controller.common;
 
-public interface PersistentVolumeAware extends DeployableContainer {
+import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 
-    String getVolumeMountPath();
+public class StorageCalculator extends LimitAndRequestCalculator {
 
-    default int getStorageLimitMebibytes() {
-        return 2048;
+    private final PersistentVolumeAware container;
+
+    public StorageCalculator(PersistentVolumeAware container) {
+        this.container = container;
+    }
+
+    public String getStorageLimit() {
+        return container.getStorageLimitMebibytes() + "Mi";
+    }
+
+    public String getStorageRequest() {
+        return applyRequestRatio(getStorageLimit());
     }
 
 }

--- a/src/main/java/org/entando/kubernetes/controller/creators/AbstractK8SResourceCreator.java
+++ b/src/main/java/org/entando/kubernetes/controller/creators/AbstractK8SResourceCreator.java
@@ -22,13 +22,13 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.entando.kubernetes.controller.DeployCommand;
 import org.entando.kubernetes.controller.KubeUtils;
-import org.entando.kubernetes.model.EntandoCustomResource;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 
 public class AbstractK8SResourceCreator {
 
-    protected final EntandoCustomResource entandoCustomResource;
+    protected final EntandoBaseCustomResource<?> entandoCustomResource;
 
-    public AbstractK8SResourceCreator(EntandoCustomResource entandoCustomResource) {
+    public AbstractK8SResourceCreator(EntandoBaseCustomResource<?> entandoCustomResource) {
         this.entandoCustomResource = entandoCustomResource;
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/creators/DatabasePreparationPodCreator.java
+++ b/src/main/java/org/entando/kubernetes/controller/creators/DatabasePreparationPodCreator.java
@@ -41,11 +41,12 @@ import org.entando.kubernetes.controller.k8sclient.SimpleK8SClient;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
 import org.entando.kubernetes.controller.spi.DbAware;
 import org.entando.kubernetes.controller.spi.DbAwareDeployable;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class DatabasePreparationPodCreator extends AbstractK8SResourceCreator {
 
-    public DatabasePreparationPodCreator(EntandoCustomResource entandoCustomResource) {
+    public DatabasePreparationPodCreator(EntandoBaseCustomResource<?> entandoCustomResource) {
         super(entandoCustomResource);
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/creators/SecretCreator.java
+++ b/src/main/java/org/entando/kubernetes/controller/creators/SecretCreator.java
@@ -29,6 +29,7 @@ import org.entando.kubernetes.controller.k8sclient.SecretClient;
 import org.entando.kubernetes.controller.spi.Deployable;
 import org.entando.kubernetes.controller.spi.IngressingDeployable;
 import org.entando.kubernetes.controller.spi.Secretive;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class SecretCreator extends AbstractK8SResourceCreator {
@@ -36,7 +37,7 @@ public class SecretCreator extends AbstractK8SResourceCreator {
     public static final String DEFAULT_CERTIFICATE_AUTHORITY_SECRET_NAME = "entando-default-ca-secret";
     public static final String TRUSTSTORE_SETTINGS_KEY = "TRUSTSTORE_SETTINGS";
 
-    public SecretCreator(EntandoCustomResource entandoCustomResource) {
+    public SecretCreator(EntandoBaseCustomResource<?> entandoCustomResource) {
         super(entandoCustomResource);
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/creators/ServiceAccountCreator.java
+++ b/src/main/java/org/entando/kubernetes/controller/creators/ServiceAccountCreator.java
@@ -31,6 +31,7 @@ import org.entando.kubernetes.controller.k8sclient.ServiceAccountClient;
 import org.entando.kubernetes.controller.spi.Deployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.KubernetesPermission;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class ServiceAccountCreator extends AbstractK8SResourceCreator {
@@ -39,7 +40,7 @@ public class ServiceAccountCreator extends AbstractK8SResourceCreator {
     private String serviceAccount;
     private String role;
 
-    public ServiceAccountCreator(EntandoCustomResource entandoCustomResource) {
+    public ServiceAccountCreator(EntandoBaseCustomResource<?> entandoCustomResource) {
         super(entandoCustomResource);
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/creators/ServiceCreator.java
+++ b/src/main/java/org/entando/kubernetes/controller/creators/ServiceCreator.java
@@ -35,17 +35,18 @@ import org.entando.kubernetes.controller.spi.Deployable;
 import org.entando.kubernetes.controller.spi.Ingressing;
 import org.entando.kubernetes.controller.spi.ServiceBackingContainer;
 import org.entando.kubernetes.controller.spi.ServiceResult;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class ServiceCreator extends AbstractK8SResourceCreator {
 
     private Service primaryService;
 
-    public ServiceCreator(EntandoCustomResource entandoCustomResource) {
+    public ServiceCreator(EntandoBaseCustomResource<?> entandoCustomResource) {
         super(entandoCustomResource);
     }
 
-    public ServiceCreator(EntandoCustomResource entandoCustomResource, Service primaryService) {
+    public ServiceCreator(EntandoBaseCustomResource<?> entandoCustomResource, Service primaryService) {
         super(entandoCustomResource);
         this.primaryService = primaryService;
     }

--- a/src/main/java/org/entando/kubernetes/controller/database/DatabaseDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/database/DatabaseDeployable.java
@@ -36,17 +36,18 @@ import org.entando.kubernetes.controller.spi.HasHealthCommand;
 import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.Secretive;
 import org.entando.kubernetes.controller.spi.ServiceBackingContainer;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class DatabaseDeployable implements Deployable<DatabaseServiceResult>, Secretive {
 
     private final Map<DbmsDockerVendorStrategy, VariableInitializer> variableInitializers = new ConcurrentHashMap<>();
     private final DbmsDockerVendorStrategy dbmsVendor;
-    private final EntandoCustomResource customResource;
+    private final EntandoBaseCustomResource<?> customResource;
     private final List<DeployableContainer> containers;
     private final String nameQualifier;
 
-    public DatabaseDeployable(DbmsDockerVendorStrategy dbmsVendor, EntandoCustomResource customResource, String nameQualifier) {
+    public DatabaseDeployable(DbmsDockerVendorStrategy dbmsVendor, EntandoBaseCustomResource<?> customResource, String nameQualifier) {
         variableInitializers.put(DbmsDockerVendorStrategy.MYSQL, vars ->
                 //No DB creation. Dbs are created during schema creation
                 vars.add(new EnvVar("MYSQL_ROOT_PASSWORD", null,
@@ -85,7 +86,7 @@ public class DatabaseDeployable implements Deployable<DatabaseServiceResult>, Se
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return customResource;
     }
 

--- a/src/main/java/org/entando/kubernetes/controller/spi/Deployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/spi/Deployable.java
@@ -35,7 +35,7 @@ public interface Deployable<T extends ServiceResult> {
 
     String getNameQualifier();
 
-    EntandoCustomResource getCustomResource();
+    EntandoBaseCustomResource<?> getCustomResource();
 
     T createResult(Deployment deployment, Service service, Ingress ingress, Pod pod);
 

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/KeycloakConsumingDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/KeycloakConsumingDeployable.java
@@ -28,6 +28,7 @@ import org.entando.kubernetes.controller.database.DatabaseServiceResult;
 import org.entando.kubernetes.controller.spi.DbAwareDeployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.PublicIngressingDeployable;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.app.EntandoApp;
 
@@ -85,7 +86,7 @@ public class KeycloakConsumingDeployable implements PublicIngressingDeployable<S
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return entandoApp;
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/SampleDeployableContainer.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/SampleDeployableContainer.java
@@ -28,12 +28,14 @@ import org.entando.kubernetes.controller.database.DbmsDockerVendorStrategy;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
 import org.entando.kubernetes.controller.spi.DbAware;
 import org.entando.kubernetes.controller.spi.IngressingContainer;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.TlsAware;
 import org.entando.kubernetes.model.EntandoBaseCustomResource;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 
 public class SampleDeployableContainer<T extends EntandoBaseCustomResource> implements IngressingContainer, DbAware, TlsAware,
-        PersistentVolumeAware {
+        PersistentVolumeAware, ParameterizableContainer {
 
     public static final String DEFAULT_IMAGE_NAME = "entando/entando-keycloak:6.0.0-SNAPSHOT";
     public static final String VAR_LIB_MYDATA = "/var/lib/mydata";
@@ -113,5 +115,10 @@ public class SampleDeployableContainer<T extends EntandoBaseCustomResource> impl
     @Override
     public String getVolumeMountPath() {
         return VAR_LIB_MYDATA;
+    }
+
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return (EntandoDeploymentSpec) entandoResource.getSpec();
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/SampleIngressingDbAwareDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/SampleIngressingDbAwareDeployable.java
@@ -56,7 +56,7 @@ public abstract class SampleIngressingDbAwareDeployable<T extends EntandoBaseCus
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return entandoResource;
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/TestServerDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/TestServerDeployable.java
@@ -32,6 +32,7 @@ import org.entando.kubernetes.controller.spi.DbAwareDeployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.IngressingDeployable;
 import org.entando.kubernetes.controller.spi.Secretive;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
 
@@ -66,7 +67,7 @@ public class TestServerDeployable implements IngressingDeployable<ServiceDeploym
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return keycloakServer;
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/barebones/BareBonesDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/barebones/BareBonesDeployable.java
@@ -28,6 +28,7 @@ import org.entando.kubernetes.controller.database.DbmsDockerVendorStrategy;
 import org.entando.kubernetes.controller.spi.Deployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.Secretive;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 
 public class BareBonesDeployable implements Deployable<BarebonesDeploymentResult>, Secretive {
@@ -35,10 +36,10 @@ public class BareBonesDeployable implements Deployable<BarebonesDeploymentResult
     public static final String MY_SERVICE_ACCOUNT = "my-service-account";
     public static final String NAME_QUALIFIER = "db";
     private List<DeployableContainer> containers = Arrays.asList(new BareBonesContainer());
-    private EntandoCustomResource customResource;
+    private EntandoBaseCustomResource<?> customResource;
     private DbmsDockerVendorStrategy dbmsVendor = DbmsDockerVendorStrategy.POSTGRESQL;
 
-    public BareBonesDeployable(EntandoCustomResource customResource) {
+    public BareBonesDeployable(EntandoBaseCustomResource<?> customResource) {
         this.customResource = customResource;
     }
 
@@ -63,7 +64,7 @@ public class BareBonesDeployable implements Deployable<BarebonesDeploymentResult
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return customResource;
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/springboot/SampleSpringBootDeployableContainer.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/springboot/SampleSpringBootDeployableContainer.java
@@ -26,12 +26,13 @@ import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.database.DatabaseSchemaCreationResult;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
 import org.entando.kubernetes.controller.spi.ParameterizableContainer;
+import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.SpringBootDeployableContainer;
 import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoDeploymentSpec;
 
 public class SampleSpringBootDeployableContainer<T extends EntandoBaseCustomResource> implements SpringBootDeployableContainer,
-        ParameterizableContainer {
+        ParameterizableContainer, PersistentVolumeAware {
 
     public static final String MY_IMAGE = "entando/entando-k8s-service";
     public static final String MY_WEB_CONTEXT = "/my-context";
@@ -100,5 +101,10 @@ public class SampleSpringBootDeployableContainer<T extends EntandoBaseCustomReso
     @Override
     public EntandoDeploymentSpec getCustomResourceSpec() {
         return customResource.getSpec() instanceof EntandoDeploymentSpec ? (EntandoDeploymentSpec) customResource.getSpec() : null;
+    }
+
+    @Override
+    public String getVolumeMountPath() {
+        return "/entando-data";
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/common/examples/springboot/SpringBootDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/common/examples/springboot/SpringBootDeployable.java
@@ -76,7 +76,7 @@ public class SpringBootDeployable<T extends EntandoBaseCustomResource> implement
     }
 
     @Override
-    public EntandoCustomResource getCustomResource() {
+    public EntandoBaseCustomResource<?> getCustomResource() {
         return customResource;
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingTestBase.java
+++ b/src/test/java/org/entando/kubernetes/controller/inprocesstest/PublicIngressingTestBase.java
@@ -194,6 +194,7 @@ public abstract class PublicIngressingTestBase implements InProcessTestUtil, Pod
         assertThat(theHttpPath("/auth").on(ingress).getBackend().getServicePort().getIntVal(), is(8080));
         assertThat(theHttpPath("/auth2").on(ingress).getBackend().getServicePort().getIntVal(), is(8081));
         assertThat(ingress.getMetadata().getAnnotations().get("kubernetes.io/ingress.class"), is("nginx"));
+        assertThat(ingress.getMetadata().getAnnotations().get("nginx.ingress.kubernetes.io/proxy-body-size"), is("50m"));
     }
 
     private EntandoPlugin buildPlugin(String sampleNamespace, String sampleName) {
@@ -202,6 +203,9 @@ public abstract class PublicIngressingTestBase implements InProcessTestUtil, Pod
                 .withName(sampleName).endMetadata().withNewSpec()
                 .withImage("docker.io/entando/entando-avatar-plugin:6.0.0-SNAPSHOT")
                 .withDbms(DbmsVendor.POSTGRESQL).withReplicas(2).withIngressHostName("myhost.name.com")
+                .withNewResourceRequirements()
+                .withFileUploadLimit("50m")
+                .endResourceRequirements()
                 .endSpec().build();
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/integrationtest/KeycloakClientTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/integrationtest/KeycloakClientTest.java
@@ -47,6 +47,7 @@ import org.entando.kubernetes.controller.integrationtest.support.TestFixturePrep
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.IngressingDeployable;
 import org.entando.kubernetes.model.DbmsVendor;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.keycloakserver.DoneableEntandoKeycloakServer;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
@@ -211,7 +212,7 @@ public class KeycloakClientTest implements FluentIntegrationTesting {
         }
 
         @Override
-        public EntandoCustomResource getCustomResource() {
+        public EntandoBaseCustomResource<?> getCustomResource() {
             return keycloakServer;
         }
 

--- a/src/test/java/org/entando/kubernetes/controller/quarkus/DummyBean.java
+++ b/src/test/java/org/entando/kubernetes/controller/quarkus/DummyBean.java
@@ -44,6 +44,7 @@ import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.IngressingContainer;
 import org.entando.kubernetes.controller.spi.IngressingDeployable;
 import org.entando.kubernetes.model.DbmsVendor;
+import org.entando.kubernetes.model.EntandoBaseCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.keycloakserver.DoneableEntandoKeycloakServer;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
@@ -302,7 +303,7 @@ public class DummyBean {
         }
 
         @Override
-        public EntandoCustomResource getCustomResource() {
+        public EntandoBaseCustomResource<?> getCustomResource() {
             return keycloakServer;
         }
 

--- a/src/test/java/org/entando/kubernetes/controller/unittest/common/ParameterizedResourceCalculatorTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/unittest/common/ParameterizedResourceCalculatorTest.java
@@ -1,0 +1,106 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.unittest.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+import org.entando.kubernetes.controller.common.ParameterizedResourceCalculator;
+import org.entando.kubernetes.controller.common.ResourceCalculator;
+import org.entando.kubernetes.controller.common.examples.barebones.BareBonesContainer;
+import org.entando.kubernetes.controller.common.examples.springboot.SampleSpringBootDeployableContainer;
+import org.entando.kubernetes.model.app.EntandoApp;
+import org.entando.kubernetes.model.app.EntandoAppSpec;
+import org.entando.kubernetes.model.app.EntandoAppSpecBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ParameterizedResourceCalculatorTest {
+
+    @AfterEach
+    @BeforeEach
+    public void resetProvidedRatio() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty());
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioAndNoOverride() {
+        ParameterizedResourceCalculator resourceCalculator = new ParameterizedResourceCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpec()), null));
+        assertThat(resourceCalculator.getCpuLimit(), is("1000m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("1024Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("100m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("102.4Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatioNoOverride() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        ParameterizedResourceCalculator resourceCalculator = new ParameterizedResourceCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpec()), null));
+        assertThat(resourceCalculator.getCpuLimit(), is("1000m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("1024Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("200m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("204.8Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioButWithALimitOverride() {
+        ParameterizedResourceCalculator resourceCalculator = new ParameterizedResourceCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withMemoryLimit("2048Mi")
+                        .withCpuLimit("2000m")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getCpuLimit(), is("2000m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("200m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("204.8Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatioButWithALimitOverride() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        ParameterizedResourceCalculator resourceCalculator = new ParameterizedResourceCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withMemoryLimit("2048Mi")
+                        .withCpuLimit("2000m")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getCpuLimit(), is("2000m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("400m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("409.6Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioButWithRequestAndLimitOverrides() {
+        ParameterizedResourceCalculator resourceCalculator = new ParameterizedResourceCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withMemoryLimit("2048Mi")
+                        .withMemoryRequest("256Mi")
+                        .withCpuLimit("2000m")
+                        .withCpuRequest("50m")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getCpuLimit(), is("2000m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("50m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("256Mi"));
+    }
+}

--- a/src/test/java/org/entando/kubernetes/controller/unittest/common/ParameterizedStorageCalculatorTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/unittest/common/ParameterizedStorageCalculatorTest.java
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.unittest.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+import org.entando.kubernetes.controller.common.ParameterizedStorageCalculator;
+import org.entando.kubernetes.controller.common.examples.springboot.SampleSpringBootDeployableContainer;
+import org.entando.kubernetes.model.app.EntandoApp;
+import org.entando.kubernetes.model.app.EntandoAppSpec;
+import org.entando.kubernetes.model.app.EntandoAppSpecBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ParameterizedStorageCalculatorTest {
+
+    @AfterEach
+    @BeforeEach
+    public void resetProvidedRatio() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty());
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioAndNoOverride() {
+        ParameterizedStorageCalculator resourceCalculator = new ParameterizedStorageCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpec()), null));
+        assertThat(resourceCalculator.getStorageLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("204.8Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatioNoOverride() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        ParameterizedStorageCalculator resourceCalculator = new ParameterizedStorageCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpec()), null));
+        assertThat(resourceCalculator.getStorageLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("409.6Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioButWithALimitOverride() {
+        ParameterizedStorageCalculator resourceCalculator = new ParameterizedStorageCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withStorageLimit("4096Mi")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getStorageLimit(), is("4096Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("409.6Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatioButWithALimitOverride() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        ParameterizedStorageCalculator resourceCalculator = new ParameterizedStorageCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withStorageLimit("4096Mi")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getStorageLimit(), is("4096Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("819.2Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatioButWithRequestAndLimitOverrides() {
+        ParameterizedStorageCalculator resourceCalculator = new ParameterizedStorageCalculator(
+                new SampleSpringBootDeployableContainer<>(new EntandoApp(new EntandoAppSpecBuilder().withNewResourceRequirements()
+                        .withStorageLimit("4096Mi")
+                        .withStorageRequest("256Mi")
+                        .endResourceRequirements().build()), null));
+        assertThat(resourceCalculator.getStorageLimit(), is("4096Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("256Mi"));
+    }
+}

--- a/src/test/java/org/entando/kubernetes/controller/unittest/common/ResourceCalculatorTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/unittest/common/ResourceCalculatorTest.java
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.unittest.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+import org.entando.kubernetes.controller.common.ResourceCalculator;
+import org.entando.kubernetes.controller.common.examples.barebones.BareBonesContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ResourceCalculatorTest {
+
+    @AfterEach
+    @BeforeEach
+    public void resetProvidedRatio() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty());
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatio() {
+        ResourceCalculator resourceCalculator = new ResourceCalculator(new BareBonesContainer());
+        assertThat(resourceCalculator.getCpuLimit(), is("800m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("256Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("80m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("25.6Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatio() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        ResourceCalculator resourceCalculator = new ResourceCalculator(new BareBonesContainer());
+        assertThat(resourceCalculator.getCpuLimit(), is("800m"));
+        assertThat(resourceCalculator.getMemoryLimit(), is("256Mi"));
+        assertThat(resourceCalculator.getCpuRequest(), is("160m"));
+        assertThat(resourceCalculator.getMemoryRequest(), is("51.2Mi"));
+    }
+}

--- a/src/test/java/org/entando/kubernetes/controller/unittest/common/StorageCalculatorTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/unittest/common/StorageCalculatorTest.java
@@ -1,0 +1,56 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.unittest.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
+import org.entando.kubernetes.controller.common.ResourceCalculator;
+import org.entando.kubernetes.controller.common.StorageCalculator;
+import org.entando.kubernetes.controller.common.examples.SampleDeployableContainer;
+import org.entando.kubernetes.controller.common.examples.barebones.BareBonesContainer;
+import org.entando.kubernetes.model.app.EntandoApp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class StorageCalculatorTest {
+
+    @AfterEach
+    @BeforeEach
+    public void resetProvidedRatio() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty());
+    }
+
+    @Test
+    public void calculateRequestsWithDefaultRatio() {
+        StorageCalculator resourceCalculator = new StorageCalculator(new SampleDeployableContainer<>(new EntandoApp()));
+        assertThat(resourceCalculator.getStorageLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("204.8Mi"));
+    }
+
+    @Test
+    public void calculateRequestsWithProvidedRatio() {
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_K8S_OPERATOR_REQUEST_TO_LIMIT_RATIO.getJvmSystemProperty(), "0.2");
+        StorageCalculator resourceCalculator = new StorageCalculator(new SampleDeployableContainer<>(new EntandoApp()));
+        assertThat(resourceCalculator.getStorageLimit(), is("2048Mi"));
+        assertThat(resourceCalculator.getStorageRequest(), is("409.6Mi"));
+    }
+}


### PR DESCRIPTION
Many files had to change due to a requirement for the EntandoBaseCustomResource instead of the EntandoCustomResource. We can in fact consider getting rid of EntandoCustomResource in future now.