### PR TITLE
ECS-454 Add support for full CA chain in single secret field

### DIFF
--- a/src/main/java/org/entando/kubernetes/controller/spi/common/TrustStoreHelper.java
+++ b/src/main/java/org/entando/kubernetes/controller/spi/common/TrustStoreHelper.java
@@ -132,7 +132,7 @@ public final class TrustStoreHelper {
         safely(() -> {
             try (InputStream stream = new ByteArrayInputStream(Base64.getDecoder().decode(entry.getValue()))) {
                 for (Certificate cert : CertificateFactory.getInstance("x.509").generateCertificates(stream)) {
-                    keyStore.setCertificateEntry(entry.getKey(), cert);
+                    keyStore.setCertificateEntry(((X509Certificate) cert).getSubjectX500Principal().getName(), cert);
                 }
             }
             return null;


### PR DESCRIPTION
This commit add the support to use a single full CA chain inside a single value of a secret.