### PR TITLE
ENG-4147 Revert parent and dependency unuseful version bumping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>7.1.1-ENG-4147-PR-40</version>
+        <version>7.1.0</version>
         <relativePath/>
     </parent>
     <artifactId>entando-k8s-operator-common</artifactId>
@@ -63,7 +63,7 @@
         <github.organization>entando-k8s</github.organization>
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-custom-model.version>7.1.1-ENG-4147-PR-69</entando-k8s-custom-model.version>
+        <entando-k8s-custom-model.version>7.1.0</entando-k8s-custom-model.version>
         <owaspSuppressionFileLocation>${project.basedir}/owasp-dependency-check-suppression.xml</owaspSuppressionFileLocation>
     </properties>
 


### PR DESCRIPTION
added bumping revert, bump must be without parent, only if needed, for patch release